### PR TITLE
fix(shizuku): crash when processing +~1MB files

### DIFF
--- a/app/src/main/aidl/com/aliernfrog/lactool/IFileService.aidl
+++ b/app/src/main/aidl/com/aliernfrog/lactool/IFileService.aidl
@@ -1,5 +1,6 @@
 package com.aliernfrog.lactool;
 
+import android.os.ParcelFileDescriptor;
 import com.aliernfrog.lactool.data.ServiceFile;
 
 interface IFileService {
@@ -15,8 +16,6 @@ interface IFileService {
 
     boolean exists(String path) = 5;
 
-    byte[] getByteArray(String path) = 6;
-
     ServiceFile getFile(String path) = 7;
 
     ServiceFile[] listFiles(String path) = 8;
@@ -26,4 +25,6 @@ interface IFileService {
     void renameFile(String oldPath, String newPath) = 10;
 
     void writeFile(String path, String text) = 11;
+
+    ParcelFileDescriptor getFd(String path) = 12;
 }

--- a/app/src/main/java/com/aliernfrog/lactool/data/ServiceFile.kt
+++ b/app/src/main/java/com/aliernfrog/lactool/data/ServiceFile.kt
@@ -29,11 +29,6 @@ fun ServiceFile.exists(): Boolean {
     return shizukuViewModel.fileService!!.exists(path)
 }
 
-fun ServiceFile.getByteArray(): ByteArray {
-    val shizukuViewModel = getKoinInstance<ShizukuViewModel>()
-    return shizukuViewModel.fileService!!.getByteArray(path)
-}
-
 fun ServiceFile.listFiles(): Array<ServiceFile>? {
     val shizukuViewModel = getKoinInstance<ShizukuViewModel>()
     return shizukuViewModel.fileService!!.listFiles(path)

--- a/app/src/main/java/com/aliernfrog/lactool/impl/FileWrapper.kt
+++ b/app/src/main/java/com/aliernfrog/lactool/impl/FileWrapper.kt
@@ -90,11 +90,12 @@ class FileWrapper(
         return cachedByteArray
     }
 
-    val painterModel: Any? = if (isFile) when (file) {
-        is File, is DocumentFileCompat -> path
-        is ServiceFile -> getByteArray()
-        else -> throw invalidFileClassException
-    } else null
+    val painterModel: Any?
+        get() =  if (isFile) when (file) {
+            is File, is DocumentFileCompat -> path
+            is ServiceFile -> getByteArray()
+            else -> throw invalidFileClassException
+        } else null
 
     fun listFiles(): List<FileWrapper> {
         val list: List<Any> = when (file) {

--- a/app/src/main/java/com/aliernfrog/lactool/impl/FileWrapper.kt
+++ b/app/src/main/java/com/aliernfrog/lactool/impl/FileWrapper.kt
@@ -1,10 +1,10 @@
 package com.aliernfrog.lactool.impl
 
 import android.content.Context
+import android.os.ParcelFileDescriptor
 import com.aliernfrog.lactool.data.ServiceFile
 import com.aliernfrog.lactool.data.delete
 import com.aliernfrog.lactool.data.exists
-import com.aliernfrog.lactool.data.getByteArray
 import com.aliernfrog.lactool.data.listFiles
 import com.aliernfrog.lactool.data.nameWithoutExtension
 import com.aliernfrog.lactool.data.renameTo
@@ -14,6 +14,7 @@ import com.aliernfrog.lactool.util.extension.nameWithoutExtension
 import com.aliernfrog.lactool.util.extension.size
 import com.aliernfrog.lactool.util.staticutil.FileUtil
 import com.lazygeniouz.dfc.file.DocumentFileCompat
+import java.io.ByteArrayOutputStream
 import java.io.File
 import java.io.InputStream
 
@@ -74,11 +75,26 @@ class FileWrapper(
             else -> throw invalidFileClassException
         }?.let { FileWrapper(it) }
 
-    val painterModel: Any? = when (file) {
-        is File, is DocumentFileCompat -> path
-        is ServiceFile -> if (isFile) file.getByteArray() else null
-        else -> throw invalidFileClassException
+    private var cachedByteArray: ByteArray? = null
+    private fun getByteArray(): ByteArray? {
+        if (file !is ServiceFile) return null
+        cachedByteArray?.let { return it }
+        val fd = shizukuViewModel.fileService!!.getFd(path)
+        val input = ParcelFileDescriptor.AutoCloseInputStream(fd)
+        val output = ByteArrayOutputStream()
+        input.copyTo(output)
+        cachedByteArray = output.toByteArray()
+        output.close()
+        input.close()
+        fd.close()
+        return cachedByteArray
     }
+
+    val painterModel: Any? = if (isFile) when (file) {
+        is File, is DocumentFileCompat -> path
+        is ServiceFile -> getByteArray()
+        else -> throw invalidFileClassException
+    } else null
 
     fun listFiles(): List<FileWrapper> {
         val list: List<Any> = when (file) {
@@ -164,7 +180,7 @@ class FileWrapper(
         return when (file) {
             is File -> file.inputStream()
             is DocumentFileCompat -> context.contentResolver.openInputStream(file.uri)
-            is ServiceFile -> file.getByteArray().inputStream()
+            is ServiceFile -> getByteArray()!!.inputStream()
             else -> throw invalidFileClassException
         }
     }

--- a/app/src/main/java/com/aliernfrog/lactool/service/FileService.kt
+++ b/app/src/main/java/com/aliernfrog/lactool/service/FileService.kt
@@ -1,5 +1,6 @@
 package com.aliernfrog.lactool.service
 
+import android.os.ParcelFileDescriptor
 import com.aliernfrog.lactool.IFileService
 import com.aliernfrog.lactool.data.ServiceFile
 import com.aliernfrog.lactool.util.getServiceFile
@@ -41,10 +42,6 @@ class FileService : IFileService.Stub() {
         return File(path).exists()
     }
 
-    override fun getByteArray(path: String): ByteArray {
-        return File(path).readBytes()
-    }
-
     override fun getFile(path: String): ServiceFile {
         return getServiceFile(File(path))
     }
@@ -68,5 +65,9 @@ class FileService : IFileService.Stub() {
         File(path).outputStream().use {
             FileUtil.writeFile(it, text)
         }
+    }
+
+    override fun getFd(path: String): ParcelFileDescriptor {
+        return ParcelFileDescriptor.open(File(path), ParcelFileDescriptor.MODE_READ_ONLY)
     }
 }


### PR DESCRIPTION
passing more than ~1MB of data using services caused a crash, instead, pass ParcelFileDescriptor and read bytes from it